### PR TITLE
upgrade polyfill service to v3

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -19,7 +19,7 @@ export function onRenderBody({ setPostBodyComponents }, options){
 	setPostBodyComponents([
 		<script
 			key='polyfill-io'
-			src={`https://cdn.polyfill.io/v2/polyfill.min.js${args}`}
+			src={`https://cdn.polyfill.io/v3/polyfill.min.js${args}`}
 		/>
 	])
 }


### PR DESCRIPTION
Just wanted to upgrade the service URL to the latest version. Since their docs are all about v3 now: https://polyfill.io/v3/api

Also it seems like technically this wouldn't be a breaking change since you can now set the polyfill library version manual in the options: https://github.com/Financial-Times/polyfill-service/blob/master/MIGRATION.md

Thanks. Let me know if I should update anything else.